### PR TITLE
Add all NSM example apps

### DIFF
--- a/nsm/helpers.go
+++ b/nsm/helpers.go
@@ -1,0 +1,45 @@
+package nsm
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	git "gopkg.in/src-d/go-git.v4"
+)
+
+func cloneRepo(repoURL string, destFolder string) error {
+	err := createRepoFolder(destFolder)
+	if err != nil {
+		return err
+	}
+
+	// Clone the repository into the temp dir
+	logrus.Infof("Cloning repo %f...", repoURL)
+	if _, err = git.PlainClone(destFolder, false, &git.CloneOptions{
+		URL:          repoURL,
+		SingleBranch: true,
+		Depth:        1,
+	}); err != nil {
+		logrus.Errorf("Error Cloning the repo", err)
+		return err
+	}
+
+	logrus.Infof("Clone of repo %s completed in %s", repoURL, destFolder)
+	return nil
+
+}
+
+func createRepoFolder(destFolder string) error {
+
+	_, err := os.Stat(destFolder)
+	if os.IsNotExist(err) {
+		err := os.MkdirAll(destFolder, os.ModePerm)
+		if err != nil {
+			err = errors.Wrapf(err, "Unable to create a folder  %s", destFolder)
+			logrus.Error(err)
+			return err
+		}
+	}
+	return err
+}

--- a/nsm/nsm-cnfs.go
+++ b/nsm/nsm-cnfs.go
@@ -1,0 +1,54 @@
+package nsm
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+)
+
+const (
+	examplesRepoURL = "https://github.com/networkservicemesh/examples.git"
+)
+
+var (
+	examplesDestDir = path.Join(os.TempDir(), "NSMExamples")
+	appsDir         = examplesDestDir + "/examples"
+)
+
+func downloadExampleApps() []string {
+	err := cloneCNFExampleApps()
+	if err != nil {
+		log.Fatalf("failed to clone CNF example apps %v", err)
+	}
+	examplesList, err := generatExampleAppsCommands()
+	if err != nil {
+		log.Fatalf("failed to generat example apps commands %v", err)
+	}
+	return examplesList
+
+}
+
+func cloneCNFExampleApps() error {
+	err := cloneRepo(examplesRepoURL, examplesDestDir)
+
+	return err
+}
+
+func generatExampleAppsCommands() ([]string, error) {
+
+	files, err := ioutil.ReadDir("./" + appsDir)
+	if err != nil {
+		log.Fatalf("failed to read dir %s, %v", appsDir, err)
+	}
+
+	examplesList := []string{}
+
+	for _, f := range files {
+		if f.IsDir() {
+			examplesList = append(examplesList, f.Name())
+		}
+	}
+
+	return examplesList, nil
+}

--- a/nsm/supported_ops.go
+++ b/nsm/supported_ops.go
@@ -15,12 +15,13 @@ type supportedOperation struct {
 }
 
 const (
-	customOpCommand       = "custom"
-	installNSMCommand     = "nsm_install"
-	installICMPCommand    = "icmp_sample_install"
-	installVPNCommand     = "vpn_sample_install"
-	installVPPICMPCommand = "vpp_icmp_sample_install"
-	installHelloNSMApp    = "hello_nsm_app"
+	customOpCommand              = "custom"
+	installNSMCommand            = "nsm_install"
+	installICMPCommand           = "icmp_sample_install"
+	installVPNCommand            = "vpn_sample_install"
+	installVPPICMPCommand        = "vpp_icmp_sample_install"
+	installHelloNSMApp           = "hello_nsm_app"
+	installCNFExampleAppsCommand = "cnf_example_app_install"
 )
 
 var supportedOps = map[string]supportedOperation{
@@ -48,5 +49,9 @@ var supportedOps = map[string]supportedOperation{
 	customOpCommand: {
 		name:   "Custom YAML",
 		opType: meshes.OpCategory_CUSTOM,
+	},
+	installCNFExampleAppsCommand: {
+		name:   "CNF Example Apps",
+		opType: meshes.OpCategory_SAMPLE_APPLICATION,
 	},
 }


### PR DESCRIPTION
This change enhances the adapter with all CNF example apps from the NSM
examples repo. They are now cloned and updated automatically

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>