### PR TITLE
[meshery-nsm] ci: add golangci-lint config and disable ST1005

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,21 @@
+linters-settings:
+  staticcheck:
+    checks: ["all", "-ST1005"]
+
+linters:
+  disable-all: true
+  enable:
+    - dogsled
+    - errcheck
+    - gofmt
+    - goimports
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - typecheck
+    - unused
+    - whitespace
+
+run:
+  timeout: 5m


### PR DESCRIPTION
### **Description**

This PR introduces a `.golangci.yaml` configuration file to the NSM adapter. It also specifically disables the **ST1005** (lowercase error strings) lint rule to ensure consistency across the Meshery ecosystem.

Fixes meshery/meshery#16867

### **Notes for Reviewers**

- Created a new `.golangci.yaml` file as it was missing in this repository.
- Configured `staticcheck` to ignore ST1005 globally.
- Enabled a standard set of linters (govet, errcheck, staticcheck, etc.) to maintain and improve code quality.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.